### PR TITLE
 Wrapper edit to avoid re-allocation of gradient

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,10 +27,9 @@ function f(x)
     4y
 end
 
-# and its gradient function that maps a vector to a vector
-function g(x)
+# and its gradient function that maps a vector x to a vector z
+function g!(z, x)
     n = length(x)
-    z = zeros(n)
     t₁ = x[2] - x[1]^2
     z[1] = 2 * (x[1] - 1) - 1.6e1 * x[1] * t₁
     for i = 2:n-1
@@ -39,11 +38,7 @@ function g(x)
         z[i] = 8 * t₂ - 1.6e1 * x[i] * t₁
     end
     z[n] = 8 * t₁
-    z
 end
-
-# define a function that returns both f(scalar) and its gradient(vector)
-func(x) = f(x), g(x)
 
 # the first argument is the dimension of the largest problem to be solved
 # the second argument is the maximum number of limited memory corrections
@@ -72,7 +67,7 @@ end
 #     iprint > 100 print details of every iteration including x and g
 # - maxfun: the maximum number of function evaluations
 # - maxiter: the maximum number of iterations
-julia> fout, xout = optimizer(func, x, bounds, m=5, factr=1e7, pgtol=1e-5, iprint=-1, maxfun=15000, maxiter=15000)
+julia> fout, xout = optimizer(f, g!, x, bounds, m=5, factr=1e7, pgtol=1e-5, iprint=-1, maxfun=15000, maxiter=15000)
 (1.0834900834300615e-9, [1.0, 1.0, 1.0, 1.00001, 1.00001, 1.00001, 1.00001, 1.00001, 1.00002, 1.00004  …  1.0026, 1.00521, 1.01045, 1.02101, 1.04246, 1.08672, 1.18097, 1.39469, 1.94516, 3.78366])
 
 # if your func needs extra arguments, a closure can be used to do the trick:

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -28,7 +28,7 @@ struct L_BFGS_B
     end
 end
 
-function (obj::L_BFGS_B)(func, x0::AbstractVector, bounds::AbstractMatrix;
+function (obj::L_BFGS_B)(func, grad!, x0::AbstractVector, bounds::AbstractMatrix;
     m=10, factr=1e7, pgtol=1e-5, iprint=-1, maxfun=15000, maxiter=15000)
     x = copy(x0)
     n = length(x)
@@ -57,8 +57,8 @@ function (obj::L_BFGS_B)(func, x0::AbstractVector, bounds::AbstractMatrix;
         setulb(n, m, x, obj.l, obj.u, obj.nbd, f, obj.g, factr, pgtol, obj.wa,
                obj.iwa, obj.task, iprint, obj.csave, obj.lsave, obj.isave, obj.dsave)
         if obj.task[1:2] == b"FG"
-            f, grad = func(x)
-            obj.g[1:n] = grad
+            f = func(x)
+            grad!(obj.g, x)
         elseif obj.task[1:5] == b"NEW_X"
             if obj.isave[30] ≥ maxiter
                 obj.task[1:43] = b"STOP: TOTAL NO. of ITERATIONS REACHED LIMIT"

--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -70,3 +70,46 @@ function (obj::L_BFGS_B)(func, grad!, x0::AbstractVector, bounds::AbstractMatrix
         end
     end
 end
+
+function (obj::L_BFGS_B)(func, x0::AbstractVector, bounds::AbstractMatrix;
+    m=10, factr=1e7, pgtol=1e-5, iprint=-1, maxfun=15000, maxiter=15000)
+    x = copy(x0)
+    n = length(x)
+    f = 0.0
+    # clean up
+    fill!(obj.task, Cuchar(' '))
+    fill!(obj.csave, Cuchar(' '))
+    fill!(obj.lsave, zero(Cint))
+    fill!(obj.isave, zero(Cint))
+    fill!(obj.dsave, zero(Cdouble))
+    fill!(obj.wa, zero(Cdouble))
+    fill!(obj.iwa, zero(Cint))
+    fill!(obj.g, zero(Cdouble))
+    fill!(obj.nbd, zero(Cint))
+    fill!(obj.l, zero(Cdouble))
+    fill!(obj.u, zero(Cdouble))
+    # set bounds
+    for i = 1:n
+        obj.nbd[i] = bounds[1,i]
+        obj.l[i] = bounds[2,i]
+        obj.u[i] = bounds[3,i]
+    end
+    # start
+    obj.task[1:5] = b"START"
+    while true
+        setulb(n, m, x, obj.l, obj.u, obj.nbd, f, obj.g, factr, pgtol, obj.wa,
+               obj.iwa, obj.task, iprint, obj.csave, obj.lsave, obj.isave, obj.dsave)
+        if obj.task[1:2] == b"FG"
+            f, grad = func(x)
+            obj.g[1:n] = grad
+        elseif obj.task[1:5] == b"NEW_X"
+            if obj.isave[30] ≥ maxiter
+                obj.task[1:43] = b"STOP: TOTAL NO. of ITERATIONS REACHED LIMIT"
+            elseif obj.isave[34] ≥ maxfun
+                obj.task[1:52] = b"STOP: TOTAL NO. of f AND g EVALUATIONS EXCEEDS LIMIT"
+            end
+        else
+            return f, x
+        end
+    end
+end

--- a/test/wrapper.jl
+++ b/test/wrapper.jl
@@ -54,4 +54,22 @@ end
     # - maxiter: the maximum number of iterations
     fout, xout = optimizer(f, g!, x, bounds, m=5, factr=1e7, pgtol=1e-5, iprint=-1, maxfun=15000, maxiter=15000)
     @test fout ≈ 1.083490083518441e-9
+    
+    #testing the original wrapper:
+    function g(x)
+        n = length(x)
+        z = zeros(n)
+        t₁ = x[2] - x[1]^2
+        z[1] = 2 * (x[1] - 1) - 1.6e1 * x[1] * t₁
+        for i = 2:n-1
+            t₂ = t₁
+            t₁ = x[i+1] - x[i]^2
+            z[i] = 8 * t₂ - 1.6e1 * x[i] * t₁
+        end
+        z[n] = 8 * t₁
+        z
+    end
+    func(x) = (f(x), g(x))
+    fout2, xout2 = optimizer(func, x, bounds, m=5, factr=1e7, pgtol=1e-5, iprint=-1, maxfun=15000, maxiter=15000)
+    @test fout2 ≈ 1.083490083518441e-9
 end

--- a/test/wrapper.jl
+++ b/test/wrapper.jl
@@ -11,10 +11,9 @@ function f(x)
     4y
 end
 
-# and its gradient function
-function g(x)
+# and its gradient function that maps a vector x to a vector z
+function g!(z, x)
     n = length(x)
-    z = zeros(n)
     t₁ = x[2] - x[1]^2
     z[1] = 2 * (x[1] - 1) - 1.6e1 * x[1] * t₁
     for i = 2:n-1
@@ -23,11 +22,7 @@ function g(x)
         z[i] = 8 * t₂ - 1.6e1 * x[i] * t₁
     end
     z[n] = 8 * t₁
-    z
 end
-
-# define a function that returns both f and g
-func(x) = f(x), g(x)
 
 @testset "wrapper" begin
     # the first argument is the dimension of the largest problem to be solved
@@ -57,6 +52,6 @@ func(x) = f(x), g(x)
     #     iprint > 100 print details of every iteration including x and g
     # - maxfun: the maximum number of function evaluations
     # - maxiter: the maximum number of iterations
-    fout, xout = optimizer(func, x, bounds, m=5, factr=1e7, pgtol=1e-5, iprint=-1, maxfun=15000, maxiter=15000)
+    fout, xout = optimizer(f, g!, x, bounds, m=5, factr=1e7, pgtol=1e-5, iprint=-1, maxfun=15000, maxiter=15000)
     @test fout ≈ 1.083490083518441e-9
 end


### PR DESCRIPTION
Replaced the tuple (f, g) with f and g!, where g!(z,x) overwrites z with the gradient at the point x. This prevents the re-allocation of the gradient vector in each iterate. For the example in README.md, this change reduced run time by 10% and halved the allocated memory. The effects are more dramatic as the number of iterations and variables grows.

To maintain backwards compatibility, I left the original wrapper as is (with its test), and added a test for the new wrapper.