### PR TITLE
Update wrapper.jl

### DIFF
--- a/src/wrapper.jl
+++ b/src/wrapper.jl
@@ -54,6 +54,7 @@ function (obj::L_BFGS_B)(func, grad!, x0::AbstractVector, bounds::AbstractMatrix
     # start
     obj.task[1:5] = b"START"
     while true
+        flush(stdout)
         setulb(n, m, x, obj.l, obj.u, obj.nbd, f, obj.g, factr, pgtol, obj.wa,
                obj.iwa, obj.task, iprint, obj.csave, obj.lsave, obj.isave, obj.dsave)
         if obj.task[1:2] == b"FG"
@@ -97,6 +98,7 @@ function (obj::L_BFGS_B)(func, x0::AbstractVector, bounds::AbstractMatrix;
     # start
     obj.task[1:5] = b"START"
     while true
+        flush(stdout)
         setulb(n, m, x, obj.l, obj.u, obj.nbd, f, obj.g, factr, pgtol, obj.wa,
                obj.iwa, obj.task, iprint, obj.csave, obj.lsave, obj.isave, obj.dsave)
         if obj.task[1:2] == b"FG"


### PR DESCRIPTION
Hello, 

I have seen a deadlock from calling `lbfgsb` many times with multi-threaded code inside `jupyter` notebooks. I have not been able to produce a MWE to submit a reliable test here, but I have been able to fix locally with the `flush(stdout)` commands added above.

It only happens when `iprint=1` and there would be a lot of printing, which made me suspect buffered IO and try the solution submitted here.

I know this may be a poor justification for the PR, but the above commands can't hurt (hopefully) :)

Cheers!